### PR TITLE
Fix script paths in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ A modular, self-evolving, embedding-based intelligent assistant for answering im
 - `cluster_merger.py`：定期用 KMeans 聚类相似问答并用 GPT 合并为精简条目。
 - `delete_old_points.py`：清理合并后的原始问答片段。
 
-### 6. `scripts/`
+### 6. `src/scripts/`
 脚本集：
 - `load_and_index.py`：将 IRCC 政策文档导入知识库。
 - `weekly_cleanup.py`：批量执行合并 + 清理流程。
@@ -78,7 +78,7 @@ TAG_RULE_DIR=tags
 python main.py
 
 # 导入 IRCC 政策文档
-python scripts/load_and_index.py data/ircc_news.html html
+python src/scripts/load_and_index.py data/ircc_news.html html
 
 # 每周知识整理（可加 crontab）
 bash run_weekly_cleanup.sh

--- a/run_weekly_cleanup.sh
+++ b/run_weekly_cleanup.sh
@@ -12,6 +12,6 @@ echo "[START] $(date) 每周知识合并清理开始..."
 cd "$(dirname "$0")"
 
 # 执行 Python 合并与清理脚本
-python3 scripts/weekly_cleanup.py
+python3 src/scripts/weekly_cleanup.py
 
 echo "[FINISH] $(date) 完成。日志已记录。"


### PR DESCRIPTION
## Summary
- reference scripts under `src/scripts` in the README
- update cleanup script to call the right Python path

## Testing
- `pytest -q` *(fails: Missing required environment variables)*