### PR TITLE
Fix canonical payload

### DIFF
--- a/src/agent_core/response_router.py
+++ b/src/agent_core/response_router.py
@@ -114,7 +114,9 @@ def generate_response(user_query: str, user_id: str = None, domain: str = None) 
     # 3. 使用规范化查询搜索相似问题
     similar_query = find_similar_canonical_query(canonical_query)
     if similar_query and similar_query.score > 0.9:
-        return similar_query.payload["answer"]
+        answer = (similar_query.payload or {}).get("answer")
+        if answer:
+            return answer
     
     # 4. 使用规范化查询检索相关文档
     relevant_docs = retrieve_relevant_documents(canonical_query, domain=domain)

--- a/src/knowledge_ingestion/qa_logger.py
+++ b/src/knowledge_ingestion/qa_logger.py
@@ -10,6 +10,7 @@
 """
 import uuid
 import datetime
+from typing import Optional
 from vector_engine.embedding_router import get_embedding
 from vector_engine.qdrant_client import (
     CANONICAL_COLLECTION,
@@ -38,7 +39,7 @@ def log_conversation(user_id: str, question: str, answer: str):
     )
     print(f"✅ 对话已记录到历史")
 
-def log_canonical_query(question: str, canonical_form: str, answer: str):
+def log_canonical_query(question: str, canonical_form: str, answer: Optional[str] = None):
     """记录标准化查询"""
     client = get_client()
     canonical_point = {

--- a/tests/test_all_collections.py
+++ b/tests/test_all_collections.py
@@ -76,14 +76,16 @@ class TestAllCollections(unittest.TestCase):
             # 规范化查询集合测试数据
             cls.canonical_test_data = [
                 (np.random.rand(1536).tolist(), {
-                    "raw": "怎么申请加拿大移民?",
-                    "canonical": "加拿大移民申请流程",
+                    "original_question": "怎么申请加拿大移民?",
+                    "canonical_form": "加拿大移民申请流程",
+                    "answer": "示例回答1",
                     "created_at": cls.now,
                     "test_id": "canonical_test_1"
                 }),
                 (np.random.rand(1536).tolist(), {
-                    "raw": "学生签证需要什么材料?",
-                    "canonical": "加拿大学生签证申请材料清单",
+                    "original_question": "学生签证需要什么材料?",
+                    "canonical_form": "加拿大学生签证申请材料清单",
+                    "answer": "示例回答2",
                     "created_at": cls.now,
                     "test_id": "canonical_test_2"
                 })


### PR DESCRIPTION
## Summary
- standardize `canonical_form` fields in Qdrant payloads
- make QA logger accept optional answers
- avoid KeyError when retrieved canonical entry has no answer
- adjust tests for new canonical payload format

## Testing
- `pytest -q` *(fails: Missing required environment variables)*