### PR TITLE
Add env defaults to integration tests

### DIFF
--- a/tests/integration/test_domain_manager.py
+++ b/tests/integration/test_domain_manager.py
@@ -11,9 +11,18 @@ import unittest
 import uuid
 from pathlib import Path
 
+# provide required environment variables before importing project modules
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("TELEGRAM_TOKEN", "test")
+os.environ.setdefault("QDRANT_API_KEY", "test")
+os.environ.setdefault("QDRANT_IS_CLOUD", "false")
+
 # 添加项目根目录到Python路径
 project_root = Path(__file__).parent.parent.parent
-sys.path.append(str(project_root))
+src_path = project_root / "src"
+for p in (project_root, src_path):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
 
 from src.config.env_manager import init_config
 from src.config.domain_manager import domain_manager
@@ -26,7 +35,6 @@ class TestDomainManager(unittest.TestCase):
     def setUpClass(cls):
         """测试类初始化"""
         print("\n准备领域管理器测试环境...")
-        # 初始化配置，使用真实API
         cls.config = init_config(test_mode=False)
         # 测试领域名称（用于临时测试）
         cls.test_domain = f"test_domain_{uuid.uuid4().hex[:8]}"

--- a/tests/integration/test_knowledge_ingestion.py
+++ b/tests/integration/test_knowledge_ingestion.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Integration tests for knowledge_ingestion modules."""
+
+import sys
+import os
+from pathlib import Path
+import unittest
+
+# set required environment variables before project imports
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("TELEGRAM_TOKEN", "test")
+os.environ.setdefault("QDRANT_API_KEY", "test")
+os.environ.setdefault("QDRANT_IS_CLOUD", "false")
+
+project_root = Path(__file__).parent.parent.parent
+src_path = project_root / "src"
+for p in (project_root, src_path):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+from src.config.env_manager import init_config
+from src.knowledge_ingestion.doc_parser import parse_html_content, store_document
+from src.knowledge_ingestion.tagger import auto_tag
+
+
+class TestKnowledgeIngestion(unittest.TestCase):
+    """Test parsing and tagging with real services."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.config = init_config(test_mode=False)
+
+    def test_parse_and_store_document(self):
+        html = "<html><body><p>This is a sample paragraph that is definitely long enough to generate an embedding.</p></body></html>"
+        paragraphs = parse_html_content(html)
+        self.assertGreater(len(paragraphs), 0)
+
+        metadata = {"source": "integration_test", "doc_type": "test"}
+        store_document(paragraphs[0], metadata)
+
+    def test_auto_tag(self):
+        text = "I currently hold a work permit and plan to apply for Express Entry."
+        tags = auto_tag(text, domain="immigration")
+        self.assertIsInstance(tags, list)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_knowledge_manager.py
+++ b/tests/integration/test_knowledge_manager.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""Integration tests for knowledge_manager modules."""
+
+import sys
+import os
+from pathlib import Path
+import unittest
+import pytest
+
+# ensure env vars exist prior to importing project modules
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("TELEGRAM_TOKEN", "test")
+os.environ.setdefault("QDRANT_API_KEY", "test")
+os.environ.setdefault("QDRANT_IS_CLOUD", "false")
+
+pytest.importorskip("langchain_community", reason="langchain_community not installed")
+
+project_root = Path(__file__).parent.parent.parent
+src_path = project_root / "src"
+for p in (project_root, src_path):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+from src.config.env_manager import init_config
+from src.knowledge_manager.ttl_cleaner import clean_expired_points
+from src.knowledge_manager.delete_old_points import delete_old_points
+from src.knowledge_manager.cluster_merger import cluster_and_merge
+from src.knowledge_manager.conflict_detector import detect_conflicts
+class TestKnowledgeManager(unittest.TestCase):
+    """Run operations that touch the vector DB with real APIs."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.config = init_config(test_mode=False)
+
+    def test_cluster_and_merge(self):
+        cluster_and_merge(n_clusters=1)
+
+    def test_ttl_cleaner(self):
+        clean_expired_points()
+
+    def test_delete_old_points(self):
+        delete_old_points()
+
+    def test_detect_conflicts(self):
+        conflicts = detect_conflicts()
+        self.assertIsInstance(conflicts, list)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/integration/test_llm_integration.py
+++ b/tests/integration/test_llm_integration.py
@@ -9,10 +9,22 @@ import sys
 import os
 import unittest
 from pathlib import Path
+import pytest
+
+# set required environment variables for configuration
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("TELEGRAM_TOKEN", "test")
+os.environ.setdefault("QDRANT_API_KEY", "test")
+os.environ.setdefault("QDRANT_IS_CLOUD", "false")
 
 # 添加项目根目录到Python路径
 project_root = Path(__file__).parent.parent.parent
-sys.path.append(str(project_root))
+src_path = project_root / "src"
+for p in (project_root, src_path):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+pytest.importorskip("langchain_community", reason="langchain_community not installed")
 
 from src.config.env_manager import init_config
 from src.config.domain_manager import domain_manager
@@ -20,7 +32,6 @@ from src.llm.factory import LLMFactory
 from src.vector_engine.embedding_router import get_embedding
 from src.agent_core.response_router import generate_response
 from src.vector_engine.qdrant_client import init_collections, get_client
-
 class TestLLMIntegration(unittest.TestCase):
     """测试LLM与其他组件的集成"""
     

--- a/tests/integration/test_vector_db.py
+++ b/tests/integration/test_vector_db.py
@@ -11,9 +11,18 @@ import unittest
 import uuid
 from pathlib import Path
 
+# default environment variables required for configuration
+os.environ.setdefault("OPENAI_API_KEY", "test")
+os.environ.setdefault("TELEGRAM_TOKEN", "test")
+os.environ.setdefault("QDRANT_API_KEY", "test")
+os.environ.setdefault("QDRANT_IS_CLOUD", "false")
+
 # 添加项目根目录到Python路径
 project_root = Path(__file__).parent.parent.parent
-sys.path.append(str(project_root))
+src_path = project_root / "src"
+for p in (project_root, src_path):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
 
 from src.config.env_manager import init_config
 from src.vector_engine.qdrant_client import (


### PR DESCRIPTION
## Summary
- inject dummy environment variables in integration tests
- ensure tests import project modules correctly
- skip complex integrations if `langchain_community` is missing

## Testing
- `pytest -q`
- `pytest tests/integration -q` *(fails: 2 tests due to API connection and expectation mismatch)*